### PR TITLE
Fix restart command.

### DIFF
--- a/arcom-server.py
+++ b/arcom-server.py
@@ -226,7 +226,8 @@ class Arcom(object):
 
   def restart(self, auth):
     self.authlog(auth, 'Restart')
-    return self.cmdSend(self.cfg.get('arcom commands', 'restart'))
+    status, msg = self.cmdSend(self.cfg.get('arcom commands', 'restart'))
+    return True, 'Restarting...'
 
   def setDateTime(self, auth):
     self.authlog(auth, 'Set Date/Time')

--- a/index.html
+++ b/index.html
@@ -152,6 +152,11 @@
               if (result) callRPC("setDateTime", [call]);
           })
       });
+      $("#restart").bind('click', function (){
+          bootbox.confirm("Confirm restart?", function(result){
+              if (result) callRPC("restart", [call]);
+          })
+      });
       $("#getIdentity").bind('click', function (){callRPC("getIdentity", [call], setTitle)});
       $("#getStatus").bind('click', function (){callRPC("status", [call], setStatus)});
       $("#getLog").bind('click', function (){callRPC("getLog", [call, 10], listLog)});


### PR DESCRIPTION
Failed to provide all the plumbing.  Also fixed the status return.  On
restart, we don’t get a controller status back (+/-).